### PR TITLE
Update Minestom to 1.21.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     `java-library`
     `maven-publish`
 }
@@ -17,12 +18,25 @@ dependencies {
     api(libs.minestom)
     compileOnly(libs.junit.params)
     compileOnly(libs.junit.api)
+
+    testImplementation(libs.junit.api)
+    testImplementation(libs.junit.params)
+    testImplementation(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.junit.engine)
 }
 
 tasks {
     compileJava {
         options.encoding = "UTF-8"
         options.release.set(21)
+    }
+
+    test {
+        useJUnitPlatform()
+        jvmArgs("-Dminestom.inside-test=true")
+        testLogging {
+            events("passed", "skipped", "failed")
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs") {
-            version("minestom", "a1d1920a04")
+            version("minestom", "4fe2993057")
             version("junit", "5.13.2")
             version("junit.platform", "1.13.1")
 
@@ -17,7 +17,6 @@ dependencyResolutionManagement {
             library("junit.params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit")
             library("junit.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
             library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").versionRef("junit.platform")
-
 
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,12 +8,17 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             version("minestom", "a1d1920a04")
-            version("junit-jupiter", "5.13.2")
+            version("junit", "5.13.2")
+            version("junit.platform", "1.13.1")
 
             library("minestom","net.minestom", "minestom-snapshots").versionRef("minestom")
 
-            library("junit-api", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit-jupiter")
-            library("junit-params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit-jupiter")
+            library("junit.api", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit")
+            library("junit.params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit")
+            library("junit.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
+            library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").versionRef("junit.platform")
+
+
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,11 +7,11 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs") {
-            version("minestom", "4fe2993057")
+            version("minestom", "2025.07.03-1.21.5")
             version("junit", "5.13.2")
             version("junit.platform", "1.13.1")
 
-            library("minestom","net.minestom", "minestom-snapshots").versionRef("minestom")
+            library("minestom","net.minestom", "minestom").versionRef("minestom")
 
             library("junit.api", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit")
             library("junit.params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit")

--- a/src/test/java/net/minestom/testing/TestPlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/testing/TestPlayerIntegrationTest.java
@@ -1,0 +1,29 @@
+package net.minestom.testing;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.testing.extension.MicrotusExtension;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MicrotusExtension.class)
+class TestPlayerIntegrationTest {
+
+    @Test
+    void testCustomPlayerCreation(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        assertNotNull(instance);
+        Player player = env.createPlayer(instance);
+        assertNotNull(player, "Player should not be null after creation");
+        assertInstanceOf(Player.class, player, "Player should be an instance of Player class");
+        assertInstanceOf(TestPlayerImpl.class, player, "Player should be an instance of TestPlayerImpl class");
+        assertEquals(instance, player.getInstance(), "Player should be in the created instance");
+        assertEquals(Pos.ZERO, player.getPosition(), "Player should start at position (0, 0, 0)");
+        assertEquals("RandName", player.getUsername(), "Player should have a random name");
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

This pull request updates the Minestom version to one that includes support for Minecraft `1.21.5`. It also adds tests to verify that the version upgrade does not introduce any regressions.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)