### PR TITLE
Set up Release Please for automated versioning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "net.onelitefeather"
-version = "0.5.7"
+version = "0.5.7" // x-release-please-version
 
 java {
     toolchain {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "simple",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "package-name": "cyano",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "build.gradle.kts"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces Release Please configuration to automate version management and changelog generation for the Cyano project. The changes include:

1. **Added `release-please-config.json`**: Configures Release Please with:
   - Simple release type for straightforward semantic versioning
   - Automatic version bumping for pre-major releases
   - Version tag format with `v` prefix (e.g., `v0.5.7`)
   - Automatic updates to `build.gradle.kts` and `CHANGELOG.md`

2. **Updated `build.gradle.kts`**: Added the `x-release-please-version` marker comment to the version string, enabling Release Please to automatically detect and update the version during releases.

These changes enable automated release workflows where version bumps and changelog entries are generated based on conventional commit messages, reducing manual release management overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is a configuration-only change that sets up infrastructure for automated releases. No testing is needed as this only affects the release process workflow, not the application code itself.

https://claude.ai/code/session_011ejAij9fBJuZYShqwjKBEk